### PR TITLE
docs: added a note in step 2 of Smoke Ping to wait up to 4 minutes for application to install

### DIFF
--- a/docs/parts/smokeping.md
+++ b/docs/parts/smokeping.md
@@ -174,6 +174,9 @@ You should now be presented with a running application. In this case, the app ru
 
 ![](../images/part3/3-smoke-ping.png)
 
+> [!NOTE]
+> Smoke Ping takes up to 4 minutes to install _after_ the server is fully provisioned. As a result, going to the IP Addrress will return nothing for up to 4 minutes.
+
 ### 3. Use Smoke Ping to find your servers best and worst latency
 
 The Smoke Ping application is constantly sending packets to multiple well known endpoints around the world and tracking how long the response takes.


### PR DESCRIPTION
### What happened
From [#2](https://github.com/dlotterman/metal_code_snippets/issues/2) - after deploying the server, Smoke Ping failed to run which looked to be an nginx installation issue.

Actually, the issue was that nginx needs ~4 minutes to fully install _after_ the server is deployed. Until then, the IP Address will return nothing and appear to have failed.

### How to fix it

On Line 177 of `docs/parts/smokeping.md` I've updated this tutorial with a `> [!NOTE]` for users. The note addresses the point above, to wait up to 4 minutes for their Smoke Ping application to appear at the IP Address.